### PR TITLE
Add feature to play video on kodi start

### DIFF
--- a/default.py
+++ b/default.py
@@ -61,4 +61,4 @@ else:
     if "play" in mode:
         waitEmbyLoaded()
         # plugin.video.emby entrypoint
-        entrypoint.doPlayback(itemid, dbid)
+        entrypoint.doPlayback(itemid, dbid, playOnStart = True)

--- a/default.py
+++ b/default.py
@@ -25,6 +25,19 @@ import entrypoint
 
 import loghandler
 
+import utils
+import time
+def waitEmbyLoaded():
+    userId = utils.window('emby_currUser')
+    server = utils.window('emby_server%s' % userId)
+    token = utils.window('emby_accessToken%s' % userId)
+    while not userId or not server or not token:
+        time.sleep(0.2)
+        userId = utils.window('emby_currUser')
+        server = utils.window('emby_server%s' % userId)
+        token = utils.window('emby_accessToken%s' % userId)
+        xbmc.log("Emby plugin.video.emby : Wait for emby loaded %s, %s, %s"%(userId, server, token))
+
 loghandler.config()
 log = logging.getLogger("EMBY.default_movies")
 
@@ -46,5 +59,6 @@ except (KeyError, IndexError):
 
 else:
     if "play" in mode:
+        waitEmbyLoaded()
         # plugin.video.emby entrypoint
         entrypoint.doPlayback(itemid, dbid)


### PR DESCRIPTION
Add compatibility with kody usage.
Video can now be start by using : 
```
kodi "plugin://plugin.video.emby.movies/?dbid=879&mode=play&id=4998255703280465dee772e9f0a970de&filename=Scream.mkv"
``` 

This feature is useful to project deblockt/kodi-recommendations-for-android-tv. This project need to run kodi with video URL as parameter.
